### PR TITLE
Issue 14: docker images with hdfs and extendeds3 tags only

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -261,7 +261,7 @@ task buildPravegaImage(type: DockerBuildTask, dependsOn: preparePravegaImage) {
     if (JavaVersion.current().isJava11Compatible()) {
         dockerFile = "${dockerDir}/Dockerfile-java-11"
     } else {
-        dockerFile = "${dockerDir}/Dockerfile"
+        dockerFile = "${dockerDir}/Dockerfile"+"${project.suffix}"
     }
     pravegaVersion = "${project.property('pravegaDockerImageVersion')}"
     String PRAVEGA_BINDINGS_VERSION="${project.version}"
@@ -271,16 +271,43 @@ task buildPravegaImage(type: DockerBuildTask, dependsOn: preparePravegaImage) {
     if (project.hasProperty('dockerRegistry')) {
         DOCKER_IMAGE_REGISTRY = "${project.property('dockerRegistry')}"
     }
-    String result = DOCKER_IMAGE_REGISTRY + "/" + DOCKER_IMAGE_REPOSITORY + ":" + PRAVEGA_BINDINGS_VERSION
+    String result = DOCKER_IMAGE_REGISTRY + "/" + DOCKER_IMAGE_REPOSITORY + ":" + PRAVEGA_BINDINGS_VERSION + "${project.suffix}"
     remoteTag = result
 }
 
 task docker(dependsOn: [buildPravegaImage]) {
     description = "Builds all docker images"
+    project.suffix = ""
+}
+
+task extendeds3Docker(type: DockerBuildTask, dependsOn: [buildPravegaImage]) {
+    description = "Builds pravega image with extendeds3 binding"
+    if (project.suffix == "-hdfs") { return; }
+    project.suffix = "-extendeds3"
+}
+
+task hdfsDocker(type: DockerBuildTask, dependsOn: [buildPravegaImage]) {
+    description = "Builds pravega image with hdfs binding"
+    if (project.suffix == "-extendeds3") { return; }
+    project.suffix = "-hdfs" 
 }
 
 task pushPravegaImage(type: DockerPushTask) {
     mustRunAfter buildPravegaImage
+}
+
+task pushExtendedS3Image(type: DockerPushTask) {
+    mustRunAfter buildPravegaImage
+    if (project.suffix == "-hdfs") { return;}
+    project.suffix = "-extendeds3" 
+
+}
+
+task pushHdfsImage(type: DockerPushTask) {
+    mustRunAfter buildPravegaImage
+    if (project.suffix == "-extendeds3") { return; }
+    project.suffix = "-hdfs" 
+
 }
 
 task dockerPush(dependsOn: [pushPravegaImage]) {
@@ -308,7 +335,7 @@ class DockerBuildTask extends Exec {
         args "--build-arg", "PRAVEGA_BINDINGS_VERSION=${->pravegaVersion}"
         args "--build-arg", "DOCKER_IMAGE_REGISTRY=pravega/pravega-storage-adapters"
         args "--build-arg", "DOCKER_IMAGE_REPOSITORY=pravega"
-        args "--build-arg", "DOCKER_IMAGE_VERSION=${->pravegaVersion}"
+        args "--build-arg", "DOCKER_IMAGE_VERSION=${->pravegaVersion}"+"${project.suffix}"
         args "-t", "${->remoteTag}"
         args "-f", "${->dockerFile}"
         args "${->dockerDir}"
@@ -324,7 +351,12 @@ class DockerPushTask extends Exec {
 
     DockerPushTask() {
         executable project.dockerExecutable
-        args "push", "${->getRemoteTag()}"
+        System.err.println("suffix=${project.suffix}")
+        if ("${project.suffix}" != "") {
+           args "push", "${->getRemoteTag()}" + "${project.suffix}"
+        } else {
+           args "push", "${->getRemoteTag()}"
+        }
     }
 
     protected void exec() {

--- a/docker/pravega/Dockerfile-extendeds3
+++ b/docker/pravega/Dockerfile-extendeds3
@@ -1,0 +1,29 @@
+#
+# Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+
+#FROM openjdk:8u212-jre-alpine3.9
+ARG DOCKER_IMAGE_REGISTRY
+ARG DOCKER_IMAGE_REPOSITORY
+ARG DOCKER_IMAGE_VERSION
+ARG PRAVEGA_IMAGE="${DOCKER_IMAGE_REGISTRY}/${DOCKER_IMAGE_REPOSITORY}:${DOCKER_IMAGE_VERSION}"
+FROM ${PRAVEGA_IMAGE}
+WORKDIR /opt/pravega
+ARG PRAVEGA_BINDINGS_VERSION
+ARG HDFS_JAR="hdfs/build/libs/pravega-hdfs-${PRAVEGA_BINDINGS_VERSION}.jar"
+ARG S3_JAR="extendeds3/build/libs/pravega-extendeds3-${PRAVEGA_BINDINGS_VERSION}.jar"
+COPY ${HDFS_JAR} /opt/pravega/lib
+COPY ${S3_JAR} /opt/pravega/lib
+ARG ONLY
+RUN if [ -z "$ONLY" ]; then echo "keeping earlier bindings jar"; else rm -rf /opt/pravega/lib/pravega-bindings-*; fi
+RUN if [ -z "$ONLY" ]; then echo "keeping other bindings jar"; else rm -rf /opt/pravega/lib/pravega-hdfs-*; fi
+RUN ls -1 /opt/pravega/lib | sort
+RUN chmod +x -R /opt/pravega/lib/
+
+ENTRYPOINT [ "/opt/pravega/scripts/entrypoint.sh" ]

--- a/docker/pravega/Dockerfile-hdfs
+++ b/docker/pravega/Dockerfile-hdfs
@@ -1,0 +1,29 @@
+#
+# Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+
+#FROM openjdk:8u212-jre-alpine3.9
+ARG DOCKER_IMAGE_REGISTRY
+ARG DOCKER_IMAGE_REPOSITORY
+ARG DOCKER_IMAGE_VERSION
+ARG PRAVEGA_IMAGE="${DOCKER_IMAGE_REGISTRY}/${DOCKER_IMAGE_REPOSITORY}:${DOCKER_IMAGE_VERSION}"
+FROM ${PRAVEGA_IMAGE}
+WORKDIR /opt/pravega
+ARG PRAVEGA_BINDINGS_VERSION
+ARG HDFS_JAR="hdfs/build/libs/pravega-hdfs-${PRAVEGA_BINDINGS_VERSION}.jar"
+ARG S3_JAR="extendeds3/build/libs/pravega-extendeds3-${PRAVEGA_BINDINGS_VERSION}.jar"
+COPY ${HDFS_JAR} /opt/pravega/lib
+COPY ${S3_JAR} /opt/pravega/lib
+ARG ONLY
+RUN if [ -z "$ONLY" ]; then echo "keeping earlier bindings jar"; else rm -rf /opt/pravega/lib/pravega-bindings-*; fi
+RUN if [ -z "$ONLY" ]; then echo "keeping other bindings jar"; else rm -rf /opt/pravega/lib/pravega-extendeds3-*; fi
+RUN ls -1 /opt/pravega/lib | sort
+RUN chmod +x -R /opt/pravega/lib/
+
+ENTRYPOINT [ "/opt/pravega/scripts/entrypoint.sh" ]

--- a/gradle.properties
+++ b/gradle.properties
@@ -9,6 +9,7 @@
 #
 
 dockerExecutable=/usr/bin/docker
+suffix=
 
 #3rd party Versions
 checkstyleToolVersion=8.23


### PR DESCRIPTION
**Change log description**  
This publishes the same image with different tags. 

**Purpose of the change**  
Fixes: #14
by adding new images

**What the code does**  
It adds the tags for the images with a suffix such as '-hdfs' or -'extendeds3'

**How to verify it**  
It verifies the image.
